### PR TITLE
Optimize Hypher setup and hyphenation

### DIFF
--- a/lib/hypher.js
+++ b/lib/hypher.js
@@ -50,11 +50,6 @@ Hypher.TrieNode;
 Hypher.prototype.createTrie = function (patternObject) {
     var size = 0,
         i = 0,
-        c = 0,
-        p = 0,
-        chars = null,
-        points = null,
-        codePoint = null,
         t = null,
         tree = {
             _points: []
@@ -63,27 +58,35 @@ Hypher.prototype.createTrie = function (patternObject) {
 
     for (size in patternObject) {
         if (patternObject.hasOwnProperty(size)) {
-            patterns = patternObject[size].match(new RegExp('.{1,' + (+size) + '}', 'g'));
-
-            for (i = 0; i < patterns.length; i += 1) {
-                chars = patterns[i].replace(/[0-9]/g, '').split('');
-                points = patterns[i].split(/\D/);
+            size = +size;
+            for (i = 0; i < patternObject[size].length; i += size) {
                 t = tree;
 
-                for (c = 0; c < chars.length; c += 1) {
-                    codePoint = chars[c].charCodeAt(0);
+                const points = [];
+                let prev = 0;
 
-                    if (!t[codePoint]) {
-                        t[codePoint] = {};
+                for (let j = 0; j < size; j++) {
+                    const char = patternObject[size][i + j];
+                    if (!char) {
+                        break;
                     }
-                    t = t[codePoint];
+                    const codePoint = char.charCodeAt(0);
+                    if (codePoint >= 48 && codePoint <= 57) {
+                        points.push(+char);
+                    } else {
+                        if (prev < 48 || prev > 57) {
+                            points.push(0);
+                        }
+                        
+                        if (!t[codePoint]) {
+                            t[codePoint] = {};
+                        }
+                        t = t[codePoint];
+                    }
+                    prev = codePoint;
                 }
 
-                t._points = [];
-
-                for (p = 0; p < points.length; p += 1) {
-                    t._points[p] = points[p] || 0;
-                }
+                t._points = points;
             }
         }
     }
@@ -129,7 +132,6 @@ Hypher.prototype.hyphenateText = function (str, minLength) {
 Hypher.prototype.hyphenate = function (word) {
     var characters,
         characterPoints = [],
-        originalCharacters,
         i,
         j,
         k,
@@ -153,8 +155,7 @@ Hypher.prototype.hyphenate = function (word) {
 
     word = '_' + word + '_';
 
-    characters = word.toLowerCase().split('');
-    originalCharacters = word.split('');
+    characters = word.toLowerCase();
     wordLength = characters.length;
 
     for (i = 0; i < wordLength; i += 1) {
@@ -182,9 +183,9 @@ Hypher.prototype.hyphenate = function (word) {
 
     for (i = 1; i < wordLength - 1; i += 1) {
         if (i > this.leftMin && i < (wordLength - this.rightMin) && points[i] % 2) {
-            result.push(originalCharacters[i]);
+            result.push(word[i]);
         } else {
-            result[result.length - 1] += originalCharacters[i];
+            result[result.length - 1] += word[i];
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Bram Stein <b.l.stein@gmail.com> (http://www.bramstein.com)",
   "devDependencies": {
     "benchmark": "=0.1.347",
-    "microtime": "^2.1.3",
     "vows": ">=0.5.6"
   },
   "directories": {

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -55,6 +55,8 @@ suite.add('Hypher', hypherDictionary, {
     setup: hypherSetup
 });
 
+suite.add('Hypher (createTrie)', hypherSetup);
+
 suite.add('Hyphenator', hyphenatorDictionary, {
     setup: hyphenatorSetup
 });

--- a/test/hypher-test.js
+++ b/test/hypher-test.js
@@ -70,13 +70,13 @@ vows.describe('Hypher').addBatch({
                 97: {
                     _points: [0, 1],
                     98: {
-                        _points: [0, 2, 0]
+                        _points: [0, 2]
                     }
                 },
                 98: {
                     _points: [0, 2],
                     99: {
-                        _points: [0, 3, 0]
+                        _points: [0, 3]
                     }
                 },
                 _points: []


### PR DESCRIPTION
The `Hyper.prototype.createTrie`-function is sailing up as one of the biggest timesinks on regular autopublishes. I've picked some autopublish-configs at random for a couple of customers and ran them through profiling in FF, and we're typically spending around 20-25% of the actual rendering just setting up Hypher. This function is also responsible for ~35% of the total memory allocations during these runs. This applies to typical full-page stories that result in half a dozen layouts, which is our most common type of autopublish.

![Screenshot 2024-03-15 at 10 00 35](https://github.com/aptoma/hypher/assets/5173221/6e9e029b-5515-4643-9f76-28225468b348)

These changes brings that down to around 6-7% while also cutting allocations in half:

![Screenshot 2024-03-15 at 10 00 26](https://github.com/aptoma/hypher/assets/5173221/ece65a82-cfd2-4485-824f-ff004da11fd3)

I've added a benchmark for `createTrie`, which shows about an 80% improvement with these changes. The changes I've made to `hyphenate` show a 60% improvement on the benchmark, but this will not be as noticeable for us since we aggressively memoize these results anyway.

I will try my best to explain the changes to `createTrie`, to the extent I understand this function myself. [This StackOverflow answer](https://tex.stackexchange.com/a/398541) is a good primer on TeX-style hyphenation as a concept. Hypher pre-groups the patterns by length, which is why the pattern files look different from what you'd find on [hyphenation.org](https://hyphenation.org/), but the patterns themselves are the same. Hypher also uses `_` to represent word boundaries, while TeX uses `.`, but this appears to only be a cosmetic change.

What `createTrie` currently does, is use regex to break each pattern group into sections according to their length. E.g. if the pattern group for length 3 starts with `2aaa1äa1ba1da1ga1j2`, this regex would break that into an array of `['2aa', 'a1ä', 'a1b', 'a1d', ...]` and so on (line 66 on master). This obviously causes a whole bunch of allocations of tiny strings, which the GC will need to deal with later. It then additionally used regex to break each pattern segment into arrays of chars and points. E.g. the pattern segment `a1b` would be broken into the arrays `['a', 'b']` and `['', '1', '']`, again causing a ton of tiny allocations.

This has been changed to two for-loops, iterating over the original pattern string in a sliding window, where we also inspect each character in the pattern segment directly instead of breaking them up into separate strings and arrays beforehand. This completely eliminates all the intermediate allocations, so we're only allocating for the final tree-structure. We also avoid any use of regex. A side-effect of this is that the point-arrays will no longer get a trailing zero-score, which seems to make no difference to the results or tests, but saves an iteration when hyphenating words, leading to a significant performance increase by complete accident.

The change to `hyphenate` is very simple. The function currently does two completely unnecessary string-splits, to convert a string into an array of chars, when you can just index the string directly and get the same result.

All 4577(!) test cases in hypher still pass. Alf-tests pass, LP tests and playwright-tests pass. We should test this on dev before going any further though. If this passes review, I think the best course of action is to publish this on `@aptoma/hypher`, and then deploy that to dev for verification. The source project has been dead for six years, which is why I'm not opening a PR there, but we can consider that later if this ends up working out.